### PR TITLE
Fix apktool.jar path

### DIFF
--- a/trueseeing/app/exploit.py
+++ b/trueseeing/app/exploit.py
@@ -96,7 +96,7 @@ class ExploitDisablePinning(Patch):
   def exploit(self):
     return self._patcher.apply(self)
 
-  def patched(self, context):
+  def apply(self, context):
     manifest = context.parsed_manifest()
     for e in manifest.xpath('.//application'):
       e.attrib['{http://schemas.android.com/apk/res/android}networkSecurityConfig'] = "@xml/network_security_config"

--- a/trueseeing/core/patch.py
+++ b/trueseeing/core/patch.py
@@ -35,6 +35,6 @@ class Patcher:
       # XXX insecure
       with tempfile.TemporaryDirectory() as d:
         os.system("(mkdir -p %(root)s/)" % dict(root=d, apk=self.apk))
-        os.system("(cd %(wd)s && java -jar %(apktool)s b -o %(root)s/patched.apk .)" % dict(root=d, apktool=pkg_resources.resource_filename(__name__, os.path.join('libs', 'apktool.jar')), wd=context.wd))
+        os.system("(cd %(wd)s && java -jar %(apktool)s b -o %(root)s/patched.apk .)" % dict(root=d, apktool=pkg_resources.resource_filename(__name__, os.path.join('..', 'libs', 'apktool.jar')), wd=context.wd))
         os.system("(cd %(root)s && jarsigner -sigalg SHA1withRSA -digestalg SHA1 -keystore %(keystore)s -storepass android -keypass android -sigfile %(sigfile)s patched.apk androiddebugkey)" % dict(root=d, keystore=SigningKey().key(), sigfile=sigfile))
         shutil.copyfile(os.path.join(d, 'patched.apk'), self.out)

--- a/trueseeing/core/patch.py
+++ b/trueseeing/core/patch.py
@@ -11,7 +11,7 @@ from trueseeing.core.context import Context
 log = logging.getLogger(__name__)
 
 class Patch:
-  def apply(self):
+  def apply(self, context):
     pass
 
 class Patcher:

--- a/trueseeing/tests/test_trueseeing.py
+++ b/trueseeing/tests/test_trueseeing.py
@@ -13,6 +13,12 @@ class TestTrueseeing(unittest.TestCase):
 
     # TODO assert count of severity
 
+  def test_exploit(self):
+    os.chdir(os.path.dirname(__file__))
+    sys.argv.append('--exploit-enable-backup')
+    sys.argv.append('libs/Android-InsecureBankv2/InsecureBankv2.apk')
+    Shell().invoke()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixed apktool.jar path.

```
$ ~/ve/trueseeing/bin/trueseeing --exploit-enable-backup InsecureBankv2.apk 
analyzed: 899473 ops, 40188 methods, 6529 classes                    
analyzed: finalizing
analyzed: done (38.91 sec)
analyze: disassembling... done.
/Users/falconws/projects/trueseeing/trueseeing/tests/libs/Android-InsecureBankv2/InsecureBankv2.apk -> /Users/falconws/.trueseeing2/7f/33/0c98cf0ce5f8adeec9e70e66fdbec4efeebb3622266753aea4fbef9f2348
Error: Unable to access jarfile /Users/falconws/projects/trueseeing/trueseeing/core/libs/apktool.jar
jarsigner: unable to open jar file: patched.apk
Traceback (most recent call last):
  File "/Users/falconws/ve/trueseeing/bin/trueseeing", line 11, in <module>
    load_entry_point('trueseeing', 'console_scripts', 'trueseeing')()
  File "/Users/falconws/projects/trueseeing/trueseeing/app/_dummy.py", line 34, in invoke
    trueseeing.app.shell.Shell().invoke()
  File "/Users/falconws/projects/trueseeing/trueseeing/app/shell.py", line 177, in invoke
    return ExploitMode(files).invoke(exploitation_mode)
  File "/Users/falconws/projects/trueseeing/trueseeing/app/exploit.py", line 45, in invoke
    ExploitEnableBackup(f, os.path.basename(f).replace('.apk', '-backupable.apk')).exploit()
  File "/Users/falconws/projects/trueseeing/trueseeing/app/exploit.py", line 83, in exploit
    return self._patcher.apply(self)
  File "/Users/falconws/projects/trueseeing/trueseeing/core/patch.py", line 23, in apply
    return self.apply_multi([patch])
  File "/Users/falconws/projects/trueseeing/trueseeing/core/patch.py", line 40, in apply_multi
    shutil.copyfile(os.path.join(d, 'patched.apk'), self.out)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/m_/t9_tst8d72s7gdfh324slcqc0000gn/T/tmp81a6qr7x/patched.apk'
```