### PR TITLE
Add a JSON Report Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ The following command line is sufficient to scan a APK (target.apk):
 
     $ trueseeing /path/to/target.apk > report.html
 
+To get a JSON format:
+
+    $ trueseeing --output=json /path/to/target.apk  > report.json
+
 To get output in more CI-friendly format:
 
     $ trueseeing --output=gcc /path/to/target.apk
-
-To get a JSON format:
-
-    $ trueseeing --output=json /path/to/target.apk
 
 To fix (not all) problems it catches:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-trueseeing is a fast, accurate and resillient vulnerabilities scanner for Android apps.  It operates on Android Packaging File (APK) and outputs a comprehensive report in HTML.  It doesn't matter if the APK is obfuscated or not.
+trueseeing is a fast, accurate and resillient vulnerabilities scanner for Android apps.  It operates on Android Packaging File (APK) and outputs a comprehensive report in HTML, JSON or a CI-friendly format.  It doesn't matter if the APK is obfuscated or not.
 
 ## Capability
 
@@ -55,6 +55,10 @@ The following command line is sufficient to scan a APK (target.apk):
 To get output in more CI-friendly format:
 
     $ trueseeing --output=gcc /path/to/target.apk
+
+To get a JSON format:
+
+    $ trueseeing --output=json /path/to/target.apk
 
 To fix (not all) problems it catches:
 

--- a/trueseeing/app/scan.py
+++ b/trueseeing/app/scan.py
@@ -18,7 +18,7 @@
 import logging
 import sys
 
-from trueseeing.core.report import CIReportGenerator, HTMLReportGenerator, ProgressReporter
+from trueseeing.core.report import CIReportGenerator, JSONReportGenerator, HTMLReportGenerator, ProgressReporter
 from trueseeing.core.context import Context
 
 log = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ class ScanMode:
 
 
 class AnalyzeSession:
-  def __init__(self, chain, ci_mode=False):
+  def __init__(self, chain, ci_mode="html"):
     self._ci_mode = ci_mode
     self._chain = chain
 
@@ -58,8 +58,10 @@ class AnalyzeSession:
       found = False
       sigs_total = len(self._chain)
 
-      if self._ci_mode:
+      if self._ci_mode == 'gcc':
         reporter = CIReportGenerator(context)
+      elif self._ci_mode == 'json':
+        reporter = JSONReportGenerator(context, ProgressReporter(sigs_total))
       else:
         reporter = HTMLReportGenerator(context, ProgressReporter(sigs_total))
 

--- a/trueseeing/app/shell.py
+++ b/trueseeing/app/shell.py
@@ -88,7 +88,7 @@ Scan mode:
   -Wno-<signame>            Disable signature (use --help-signatures to list signatures)
   --fingerprint             Print fingerprint
   --grab <package name>     Grab package from device
-  --output=html|gcc         Output mode (html: HTML, gcc: Text)
+  --output=html|gcc|json    Output mode (html: HTML, gcc: Text, json: JSON)
 
 Exploitation mode:
   --exploit-resign          Exploit mode: Replace signature
@@ -160,7 +160,7 @@ Misc:
       if o in ['--inspect']:
         inspection_mode = True
       if o in ['--output']:
-        ci_mode = (a == 'gcc')
+        ci_mode = a
       if o in ['--version']:
         print(Shell.version())
         return 0

--- a/trueseeing/core/report.py
+++ b/trueseeing/core/report.py
@@ -19,6 +19,7 @@ import sys
 import logging
 import jinja2
 import pkg_resources
+import json
 
 from trueseeing.core.issue import Issue
 from trueseeing.core.cvss import CVSS3Scoring
@@ -119,6 +120,47 @@ class HTMLReportGenerator(ReportGenerator):
         issues_info=len([_ for _ in issues if _['severity'] == 'Info'])
       )
       self._write(self._template.render(app=app, issues=issues))
+
+  def _write(self, x):
+    sys.stdout.write(x)
+    sys.stdout.flush()
+
+class JSONReportGenerator(ReportGenerator):
+  def __init__(self, context, progress):
+    super().__init__(context, progress)
+
+  def generate(self):
+    super().generate()
+    with self._context.store().db as db:
+      issues = []
+      for row, no in zip(db.execute('select distinct detector, summary, synopsis, description, seealso, solution, cvss3_score, cvss3_vector from analysis_issues order by cvss3_score desc'), range(1, 2**32)):
+        instances = []
+        issues.append(dict(
+          no=no,
+          detector=row[0],
+          summary=row[1].title(),
+          synopsis=row[2],
+          description=row[3],
+          seealso=row[4],
+          solution=row[5],
+          cvss3_score=row[6],
+          cvss3_vector=row[7],
+          severity=CVSS3Scoring.severity_of(row[6]).title(),
+          instances=instances
+          ))
+        for m in db.execute('select * from analysis_issues where detector=:detector and summary=:summary and cvss3_score=:cvss3_score', {v:row[k] for k,v in {0:'detector', 1:'summary', 6:'cvss3_score'}.items()}):
+          issue = Issue.from_analysis_issues_row(m)
+          instances.append(dict(
+            info=issue.brief_info(),
+            source=issue.source,
+            row=issue.row,
+            col=issue.col))
+
+      app = dict(
+        package=self._context.parsed_manifest().getroot().xpath('/manifest/@package', namespaces=dict(android='http://schemas.android.com/apk/res/android'))[0],
+        issues=len(issues)
+      )
+      self._write(json.dumps({"app": app, "issues": issues}, indent=2))
 
   def _write(self, x):
     sys.stdout.write(x)


### PR DESCRIPTION
Hi,

The HTML report from scan mode is hard to parse, a JSON report allows for much easier use.

I added a JSON Report Generator Class. It works the same as the HTML Report Class (might be possible to refactor some code there). I also added the CLI option to choose between HTML, JSON and CLI reports. The default is still HTML reports.

Unlike the HTML report I added only a single array of issues to the JSON as it can be easily filtered or otherwise and provides a single array to access all issues.

I tried to add as much information to the JSON report as possbile, but I'm not sure if everything that trueseeing collects is added right now. Feel free to add any additional data I might have missed.


Thanks for considering